### PR TITLE
Only prompts user for semantic unit in embrace-add if region isn't already set

### DIFF
--- a/embrace.el
+++ b/embrace.el
@@ -543,13 +543,18 @@
 ;;;###autoload
 (defun embrace-add ()
   (interactive)
-  (let ((mark-func (assoc-default (read-char "Semantic unit: ")
-                                  embrace-semantic-units-alist))
+  (let (mark-func 
         overlay)
-    (unless (fboundp mark-func)
-      (error "No such a semantic unit"))
     (save-excursion
-      (funcall mark-func)
+      ;; only ask for semantic unit if region isn't already set
+      (cond ((not (use-region-p))
+             (setq mark-func (assoc-default (read-char "Semantic unit: ")
+                                            embrace-semantic-units-alist))
+             (unless (fboundp mark-func)
+               (error "No such a semantic unit"))
+             (funcall mark-func)
+             ))
+
       (setq overlay (make-overlay (region-beginning) (region-end) nil nil t))
       (embrace--insert (read-char "Add pair: ") overlay)
       (delete-overlay overlay))))


### PR DESCRIPTION
First off, I just found this in the package-list today and I LOVE this project. So good. thank you so much. 

Opened this PR because I find I use expand-region a lot to select the thing i want to operate on so asking for the semantic unit in that case was redundant. 
