### PR TITLE
Replace window.el internal function use

### DIFF
--- a/embrace.el
+++ b/embrace.el
@@ -632,8 +632,8 @@
       (goto-char (point-min)))
     (if (get-buffer-window embrace--help-buffer)
         (display-buffer-reuse-window embrace--help-buffer alist)
-      (display-buffer-in-major-side-window
-       embrace--help-buffer 'bottom 0 alist))))
+      (display-buffer-in-side-window
+       embrace--help-buffer alist))))
 
 (defun embrace--pair-struct-to-keys (pair-struct)
   (list (propertize (format "%c" (embrace-pair-struct-key pair-struct))


### PR DESCRIPTION
Ref:
https://github.com/emacs-mirror/emacs/commit/b8fd71d5709650c1aced92c772f70595c51881d2#diff-c8c1f7fce6ce8013f581877ead1a78f6L842

`display-buffer-in-major-side-window` is internal function used by `window.el`.
It got renamed in Emacs 26 which causes void function errors. Replace it with
appropriate function for external library use.